### PR TITLE
Fixing disable windows store updates by correct value

### DIFF
--- a/tasks/section_18/section_18.10/cis_18.10.65.x.yml
+++ b/tasks/section_18/section_18.10/cis_18.10.65.x.yml
@@ -30,7 +30,7 @@
   ansible.windows.win_regedit:
       path: HKLM:\Software\Policies\Microsoft\WindowsStore
       name: AutoDownload
-      data: 4
+      data: 2
       type: dword
   when: win11cis_rule_18_10_65_3
   tags:


### PR DESCRIPTION
**Overall Review of Changes:**
This PR fixes an incorrect registry value for CIS control 18.10.65.3 "Ensure 'Turn off Automatic Download and Install of updates' is set to 'Disabled'". The AutoDownload registry key under HKLM:\Software\Policies\Microsoft\WindowsStore was incorrectly set to 4 (Always On), which actually enables automatic downloads. This has been corrected to 2 (Always Off) to properly disable automatic downloads as required by the CIS benchmark.

**Issue Fixes:**
No open issues on this.

**Enhancements:**
Fixed registry value for AutoDownload from 4 to 2 in tasks/section_18/section_18.10/cis_18.10.65.x.yml
This ensures the policy correctly disables automatic download and installation of updates from the Microsoft Store as per CIS Level 1 corporate/enterprise environment requirements

**How has this been tested?:**
It's verified in our custom image
