### PR TITLE
fix: update conditional logic for Ansible 2.19+ compatibility 

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,7 +18,7 @@
   ansible.builtin.assert:
       that:
           - ansible_os_family == 'Windows'
-          - ansible_distribution | regex_search('(Microsoft Windows 11 Enterprise)')
+          - "'Microsoft Windows 11 Enterprise' in ansible_distribution"
       success_msg: "{{ ansible_distribution }} Distribution {{ ansible_distribution_major_version }} is the detected operating system."
       fail_msg: "This role can only be run against Microsoft Windows 11 Enterprise. {{ ansible_distribution }} {{ ansible_distribution_major_version }} is not supported."
   tags:


### PR DESCRIPTION
**Overall Review of Changes:**
Update the check against OS name to work with Ansible 2.19 and later

**Issue Fixes:**
- https://github.com/ansible-lockdown/Windows-11-CIS/issues/37

**How has this been tested?:**
Tested against Windows 11 Client in AWX

